### PR TITLE
[Haskell-Way] Idiomatized MergeSort.hs

### DIFF
--- a/haskell-way/src/mergesort.hs
+++ b/haskell-way/src/mergesort.hs
@@ -3,28 +3,21 @@ module MergeSort where
 -- I am a Haskell noob at the moment. This code was written for shits and giggles when I was
 -- reading the merge-sort code for clojure. I just thought, why not translate it to haskell when you are learning it
 -- I am sure there will be a more elegant way to implement in Haskell, which I will updtate to
-    
-mergeSortArray :: (Ord a) => [a] -> [a] -> [a]
-mergeSortArray [] [] = []
-mergeSortArray [] y = y
-mergeSortArray x [] = x
-        
-mergeSortArray x y = if (head x) < (head y) then
-    (head x) : mergeSortArray (tail x) y else
-        (head y) : mergeSortArray (tail y) x
+
+merge :: (Ord a) => [a] -> [a] -> [a]
+merge [] ys = ys
+merge xs [] = xs        
+merge l@(x:xs) r@(y:ys) | x < y     = x : merge xs r
+                        | otherwise = y : merge l ys
                 
 mergeSort :: (Ord a) => [a] -> [a]
-mergeSort x =
-    let midPoint = length x `div` 2
-        firstHalf = take midPoint x
-        secondHalf = drop midPoint x
-    in if length firstHalf == 1 && length secondHalf == 1 then 
-        mergeSortArray firstHalf secondHalf else
-            if length firstHalf == 0 then mergeSortArray [] secondHalf else
-                if length secondHalf == 0 then mergeSortArray [] firstHalf else
-                    mergeSortArray (mergeSort firstHalf) (mergeSort secondHalf)
-    
+mergeSort  [] = []
+mergeSort [x] = [x]
+mergeSort  xs = merge (mergeSort firstHalf) (mergeSort secondHalf)
+  where
+    (firstHalf, secondHalf) = splitAt (length xs `div` 2)
+
 -- Poor man's test                    
 main :: IO ()
-main = do
-    let x = mergeSort [6, 7, 2, 3, -5, 9, 4, 11, 1, 1] in print x
+main = 
+  print $ mergeSort [6, 7, 2, 3, -5, 9, 4, 11, 1, 1]


### PR DESCRIPTION
The implementation as it was suffered from "boolean blindness" which is a common occurence in translations of imperative algorithms into a functional style. It describes the phenomenon that structural properties of data and contextual knowledge from branches and pattern-matching is disregarded in favor of boolean-valued tests. E.g. the cascading branches on the length of the list in `mergeSort` can be much more succinctly expressed by a collection of patterns.

Quick notes for idiomatic Haskell:
- favor pattern-matching over conditionals
- favor pattern-matching over unsafe destructors (`head`, `tail`, etc).
- favor `where` blocks over `lets`