### PR TITLE
[Haskell-Way] setup Cabal and related adjustments

### DIFF
--- a/haskell-way/Setup.hs
+++ b/haskell-way/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/haskell-way/haskell-way.cabal
+++ b/haskell-way/haskell-way.cabal
@@ -1,0 +1,25 @@
+cabal-version:       2.4
+
+name:                haskell-way
+version:             0.1
+synopsis:            Small programs (algorithms) in Haskell
+homepage:            https://github.com/ashwinbhaskar/functional-way
+
+library
+  exposed-modules:
+      GravitySort
+    , MergeSort
+  build-depends:       base ^>=4.12.0.0
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  other-modules:
+    Test.Util
+  build-depends:
+      base ^>=4.12.0.0
+    , haskell-way
+  hs-source-dir:       test
+  main-is:             Test.hs
+  default-language:    Haskell2010

--- a/haskell-way/src/GravitySort.hs
+++ b/haskell-way/src/GravitySort.hs
@@ -1,4 +1,4 @@
-module GravitySort where
+module GravitySort (gravitySort) where
 
 {- Gravity/Bead Sort in Haskell
  -
@@ -21,4 +21,3 @@ matricize = map (\n -> take n . repeat $ 1)
 -- count number of 1s on each column of a binary matrix
 collapse :: [[Int]] -> [Int]
 collapse = map length . transpose
-

--- a/haskell-way/src/MergeSort.hs
+++ b/haskell-way/src/MergeSort.hs
@@ -1,4 +1,4 @@
-module MergeSort where
+module MergeSort (mergeSort) where
 
 -- I am a Haskell noob at the moment. This code was written for shits and giggles when I was
 -- reading the merge-sort code for clojure. I just thought, why not translate it to haskell when you are learning it
@@ -15,7 +15,7 @@ mergeSort  [] = []
 mergeSort [x] = [x]
 mergeSort  xs = merge (mergeSort firstHalf) (mergeSort secondHalf)
   where
-    (firstHalf, secondHalf) = splitAt (length xs `div` 2)
+    (firstHalf, secondHalf) = splitAt (length xs `div` 2) xs
 
 -- Poor man's test                    
 main :: IO ()

--- a/haskell-way/test/Test.hs
+++ b/haskell-way/test/Test.hs
@@ -1,0 +1,30 @@
+module Main where
+
+import GravitySort
+import MergeSort
+import System.Exit
+import Test.Util
+
+-- testing array
+testList = [12234, 34532, 543, 1, 324, 6534]
+
+-- test gravity sort on a given list
+testGravitySort :: [Int] -> Bool
+testGravitySort x = and [isSorted x', areSame x x']
+  where x' = gravitySort x
+
+-- test merge sort on a given list
+testMergeSort :: (Ord a) => [a] -> Bool
+testMergeSort x = and [isSorted x', areSame x x']
+  where x' = mergeSort x
+
+main :: IO ()
+main = if and allTests then exitSuccess else exitFailure
+
+allTests :: [Bool]
+allTests =  [
+    testGravitySort testList
+  , testMergeSort testList
+  ]
+
+  

--- a/haskell-way/test/Test/Util.hs
+++ b/haskell-way/test/Test/Util.hs
@@ -1,0 +1,24 @@
+module Test.Util (
+    areSame
+  , isSorted
+  ) where
+
+import Data.List
+
+-- check if two lists are the same using Haskell's own sorting function
+areSame :: (Ord a) => [a] -> [a] -> Bool
+areSame a b = sort a == sort b
+
+-- check if a list is sorted
+isSorted x = isAscending x || isDescending x
+
+-- check if a list is sorted ascendingly
+isAscending :: (Ord a) => [a] -> Bool
+isAscending []       = True
+isAscending [_]      = True
+isAscending (a:b:xs) = if a <= b then isAscending xs else False
+
+-- check if a list is sorted descendingly
+isDescending :: (Ord a) => [a] -> Bool
+isDescending = isAscending . reverse
+


### PR DESCRIPTION
Set up Cabal for building with `cabal v2-build` and running the test suite with `cabal v2-test`. The test suite currently contains a couple of utility functions to test sorting algorithms and tests for both the current implementations of gravity and merge sort. Renamed a couple of files because Cabal requires it. While testing the build system I fixed `MergeSort.hs`: the current version fails to compile. It should now be possible to set up Travis to run Cabal builds and tests automatically.